### PR TITLE
BugFix hardcoded expiry date

### DIFF
--- a/javasource/jwt/helpers/RSAKeyPairGenerator.java
+++ b/javasource/jwt/helpers/RSAKeyPairGenerator.java
@@ -87,7 +87,7 @@ public class RSAKeyPairGenerator {
 		Date currentDate = new Date(System.currentTimeMillis());
 		Calendar calendar = Calendar.getInstance();
 		calendar.setTime(currentDate);
-		calendar.add(Calendar.YEAR, 3);
+		calendar.add(Calendar.YEAR, validity);
 		Date futureDate = calendar.getTime();
 		
 		X509v3CertificateBuilder certBuilder = new X509v3CertificateBuilder(x500NameIssuer, new BigInteger("1234"), currentDate, futureDate, x500NameSubject, spkInfo);


### PR DESCRIPTION
As described by ArjenLammers in his MR and kmarcinkowski-objectivity in his opened issue, 3 years was hardcoded as validity in the created public certificate and the variable for years validity was unused. This is now fixed, a generated public certificate is now valid for the specified amount of years.